### PR TITLE
Improve line matching

### DIFF
--- a/lib/capistrano_colors/logger.rb
+++ b/lib/capistrano_colors/logger.rb
@@ -37,7 +37,7 @@ module Capistrano
       @@sorted_color_matchers.each do |filter|
         
         if (filter[:level] == level || filter[:level].nil?)
-          if message =~ filter[:match]
+          if message =~ filter[:match] || line_prefix =~ filter[:match]
             color = filter[:color]
             attribute = filter[:attribute]
             message = filter[:prepend] + message unless filter[:prepend].nil?


### PR DESCRIPTION
The default filter to turn error lines red is broken.  It attempts to match on text in the line_prefix, but the matching code doesn't look at line_prefix.  Fixed by matching on line_prefix in addition to message.
